### PR TITLE
regression-testing-dashboard-api-public to 0.0.24

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,6 +13,9 @@ dependencies:
 - name: gv-python-app
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: regression-testing-dashboard-api-public
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.24
 - name: test-jenkinsx-cicd-1
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
Promote regression-testing-dashboard-api-public to version 0.0.24